### PR TITLE
🐛 stub active_support/broadcast_logger

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
 require "kettle/soup/cover/config"
 
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/lib/active_support"
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-Since version 2.0.0, the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,4 @@ end
 # Linting
 gem "standard", "~> 1.42", ">= 1.42.1" # Ruby >= 3.0
 gem "reek", "~> 6.3", ">= 6.3.0" # Ruby >= 3.0
+gem "activesupport-logger", path: "/Users/pboling/src/my/activesupport-logger"

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,3 @@ end
 # Linting
 gem "standard", "~> 1.42", ">= 1.42.1" # Ruby >= 3.0
 gem "reek", "~> 6.3", ">= 6.3.0" # Ruby >= 3.0
-gem "activesupport-logger", path: "/Users/pboling/src/my/activesupport-logger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,18 @@ PATH
       stringio (>= 0.0.2)
       version_gem (~> 1.1, >= 1.1.4)
 
+PATH
+  remote: /Users/pboling/src/my/activesupport-logger
+  specs:
+    activesupport-logger (2.0.0)
+      activesupport (>= 5.2)
+      backports (~> 3.25, >= 3.25.0)
+      logger (~> 1.6, >= 1.6.1)
+      mutex_m (~> 0.1)
+      rdoc (~> 6.8, >= 6.8.1)
+      stringio (>= 0.0.2)
+      version_gem (~> 1.1, >= 1.1.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,14 +37,6 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    activesupport-logger (2.0.0)
-      activesupport (>= 5.2)
-      backports (~> 3.25, >= 3.25.0)
-      logger (~> 1.6, >= 1.6.1)
-      mutex_m (~> 0.1)
-      rdoc (~> 6.8, >= 6.8.1)
-      stringio (>= 0.0.2)
-      version_gem (~> 1.1, >= 1.1.4)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -235,6 +239,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport-broadcast_logger!
+  activesupport-logger!
   appraisal (~> 2.5)
   byebug (>= 11)
   kettle-soup-cover (~> 1.0, >= 1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,19 +3,7 @@ PATH
   specs:
     activesupport-broadcast_logger (2.0.0)
       activesupport (>= 5.2)
-      activesupport-logger (~> 2.0, >= 2.0.0)
-      logger (~> 1.6, >= 1.6.1)
-      mutex_m (~> 0.1)
-      rdoc (~> 6.8, >= 6.8.1)
-      stringio (>= 0.0.2)
-      version_gem (~> 1.1, >= 1.1.4)
-
-PATH
-  remote: /Users/pboling/src/my/activesupport-logger
-  specs:
-    activesupport-logger (2.0.0)
-      activesupport (>= 5.2)
-      backports (~> 3.25, >= 3.25.0)
+      activesupport-logger (~> 2.0, >= 2.0.1)
       logger (~> 1.6, >= 1.6.1)
       mutex_m (~> 0.1)
       rdoc (~> 6.8, >= 6.8.1)
@@ -25,7 +13,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2)
+    activesupport (8.0.0)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -37,6 +25,15 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    activesupport-logger (2.0.1)
+      activesupport (>= 5.2)
+      backports (~> 3.25, >= 3.25.0)
+      logger (~> 1.6, >= 1.6.1)
+      mutex_m (~> 0.1)
+      rdoc (~> 6.8, >= 6.8.1)
+      stringio (>= 0.0.2)
+      version_gem (~> 1.1, >= 1.1.4)
     ansi (1.5.0)
     appraisal (2.5.0)
       bundler
@@ -97,7 +94,7 @@ GEM
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
     logger (1.6.1)
-    minitest (5.25.1)
+    minitest (5.25.2)
     mutex_m (0.3.0)
     ostruct (0.6.1)
     parallel (1.26.3)
@@ -223,6 +220,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
+    uri (1.0.2)
     version_gem (1.1.4)
     yard (0.9.37)
     yard-junk (0.0.10)
@@ -230,7 +228,7 @@ GEM
       ostruct
       rainbow
       yard
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin-22
@@ -239,7 +237,6 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport-broadcast_logger!
-  activesupport-logger!
   appraisal (~> 2.5)
   byebug (>= 11)
   kettle-soup-cover (~> 1.0, >= 1.0.4)

--- a/activesupport-broadcast_logger.gemspec
+++ b/activesupport-broadcast_logger.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
 
   # Runtime Dependencies
   spec.add_dependency("activesupport", ">= 5.2")
-  spec.add_dependency("activesupport-logger", "~> 2.0", ">= 2.0.0")
+  spec.add_dependency("activesupport-logger", "~> 2.0", ">= 2.0.1")
   spec.add_dependency("version_gem", "~> 1.1", ">= 1.1.4")
 
   # Documentation

--- a/lib/active_support/broadcast_logger.rb
+++ b/lib/active_support/broadcast_logger.rb
@@ -1,0 +1,4 @@
+# This is a stub
+# It will prevent vanilla ActiveSupport from loading its own broken logger tooling.
+# Instead, we'll load the fixed replacement logging tooling from this library!
+require_relative "../activesupport-broadcast_logger"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Loading "active_support" normally here ensures this library will work,
+#   even if loaded after the vanilla ActiveSupport.
+# Unfortunately, it also results in 0% code coverage, because this gem gets loaded too early.
+# require "active_support"
+
 # External Deps
 require "minitest"
 require "test-unit"


### PR DESCRIPTION
- This library is intended to replace active_support/broadcast_logger, but it can't if active_support/broadcast_logger has already been loaded
- stubbing the file to load this library's broadcast_logger, instead of vanilla, hijacks Rails internals to work for us