### PR TITLE
🔖 Prepare release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Removed
 
+## [2.0.1] - 2024-11-21
+- COVERAGE:  97.06% -- 66/68 lines in 3 files
+- BRANCH COVERAGE:  90.00% -- 9/10 branches in 3 files
+- 73.68% documented
+### Fixed
+- Compatibility with ActiveSupport
+    - Many libraries do `require "active_support"`
+
 ## [2.0.0] - 2024-11-21
 - COVERAGE:  97.06% -- 66/68 lines in 3 files
 - BRANCH COVERAGE:  90.00% -- 9/10 branches in 3 files

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activesupport-broadcast_logger (2.0.0)
+    activesupport-broadcast_logger (2.0.1)
       activesupport (>= 5.2)
       activesupport-logger (~> 2.0, >= 2.0.1)
       logger (~> 1.6, >= 1.6.1)

--- a/lib/activesupport/broadcast_logger/version.rb
+++ b/lib/activesupport/broadcast_logger/version.rb
@@ -3,7 +3,7 @@
 module Activesupport
   module BroadcastLogger
     module Version
-      VERSION = "2.0.0"
+      VERSION = "2.0.1"
     end
   end
 end


### PR DESCRIPTION
## [2.0.1] - 2024-11-21
- COVERAGE:  97.06% -- 66/68 lines in 3 files
- BRANCH COVERAGE:  90.00% -- 9/10 branches in 3 files
- 73.68% documented
### Fixed
- Compatibility with ActiveSupport
    - Many libraries do `require "active_support"`
